### PR TITLE
Add attribute filter and extend local tests

### DIFF
--- a/wikipedia_cleanup/create_new_data_format.py
+++ b/wikipedia_cleanup/create_new_data_format.py
@@ -10,7 +10,7 @@ from tqdm.contrib.concurrent import process_map
 
 from wikipedia_cleanup.data_filter import (
     AbstractDataFilter,
-    TestDiscardAttributesDataFilter,
+    DiscardAttributesDataFilter,
     filter_changes_with,
     generate_default_filters,
     merge_filter_stats_into,
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     # ADD YOUR FILTERS, consider: get_default_filters
     filters = generate_default_filters() if args.use_default_filters else []
-    filters.insert(0, TestDiscardAttributesDataFilter())
+    filters.append(DiscardAttributesDataFilter(["page_id"]))
     input_files = list(Path(args.input_folder).rglob("*.7z"))
     input_files.extend(list(Path(args.input_folder).rglob("*.json")))
     input_files.extend(list(Path(args.input_folder).rglob("*.pickle")))

--- a/wikipedia_cleanup/create_new_data_format.py
+++ b/wikipedia_cleanup/create_new_data_format.py
@@ -10,6 +10,7 @@ from tqdm.contrib.concurrent import process_map
 
 from wikipedia_cleanup.data_filter import (
     AbstractDataFilter,
+    TestDiscardAttributesDataFilter,
     filter_changes_with,
     generate_default_filters,
     merge_filter_stats_into,
@@ -99,6 +100,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     # ADD YOUR FILTERS, consider: get_default_filters
     filters = generate_default_filters() if args.use_default_filters else []
+    filters.insert(0, TestDiscardAttributesDataFilter())
     input_files = list(Path(args.input_folder).rglob("*.7z"))
     input_files.extend(list(Path(args.input_folder).rglob("*.json")))
     input_files.extend(list(Path(args.input_folder).rglob("*.pickle")))

--- a/wikipedia_cleanup/data_filter.py
+++ b/wikipedia_cleanup/data_filter.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import List
 
-from wikipedia_cleanup.schema import InfoboxChange
+from wikipedia_cleanup.schema import InfoboxChange, SparseInfoboxChange
 
 INITIAL_STATS_VALUE = -1
 
@@ -84,6 +84,75 @@ class AbstractDataFilter(ABC):
             f"{self.__class__.__name__}\n"
             f'{"+" * base_print_width}\n' + str(self.filter_stats)
         )
+
+
+class DiscardAttributesDataFilter(AbstractDataFilter):
+    def _filter_for_property(self, changes: List[InfoboxChange]) -> List[InfoboxChange]:
+        raise NotImplementedError("This method should never be called.")
+
+    def filter(
+        self, changes: List[InfoboxChange], initial_num_changes: int
+    ) -> List[InfoboxChange]:
+        self.filter_stats.initial_num_changes = initial_num_changes
+        self.filter_stats.input_num_changes = initial_num_changes
+        self.filter_stats.output_num_changes = initial_num_changes
+
+        sparse_changes = []
+        for change in changes:
+            sparse_change: InfoboxChange = SparseInfoboxChange()  # type: ignore
+
+            sparse_change.page_id = change.page_id
+            sparse_change.property_name = change.property_name
+            sparse_change.value_valid_to = change.value_valid_to
+            sparse_change.value_valid_from = change.value_valid_from
+            sparse_change.current_value = change.current_value
+            sparse_change.previous_value = change.previous_value
+            sparse_change.num_changes = change.num_changes
+
+            sparse_change.page_title = change.page_title
+            sparse_change.revision_id = change.revision_id
+            sparse_change.edit_type = change.edit_type
+            sparse_change.property_type = change.property_type
+            sparse_change.comment = change.comment
+            sparse_change.infobox_key = change.infobox_key
+            sparse_change.username = change.username
+            sparse_change.user_id = change.user_id
+            sparse_change.position = change.position
+            sparse_change.template = change.template
+            sparse_change.revision_valid_to = change.revision_valid_to
+
+            sparse_changes.append(sparse_change)
+        return sparse_changes
+
+
+class TestDiscardAttributesDataFilter(AbstractDataFilter):
+    def _filter_for_property(self, changes: List[InfoboxChange]) -> List[InfoboxChange]:
+        raise NotImplementedError("This method should never be called.")
+
+    def filter(
+        self, changes: List[InfoboxChange], initial_num_changes: int
+    ) -> List[InfoboxChange]:
+        self.filter_stats.initial_num_changes = initial_num_changes
+        self.filter_stats.input_num_changes = initial_num_changes
+        self.filter_stats.output_num_changes = initial_num_changes
+
+        sparse_changes = []
+        for change in changes:
+            sparse_change: InfoboxChange = SparseInfoboxChange()  # type: ignore
+
+            sparse_change.page_id = change.page_id
+            sparse_change.property_name = change.property_name
+            sparse_change.value_valid_to = change.value_valid_to
+            sparse_change.value_valid_from = change.value_valid_from
+            sparse_change.current_value = change.current_value
+            sparse_change.previous_value = change.previous_value
+            sparse_change.num_changes = change.num_changes
+
+            sparse_change.infobox_key = change.infobox_key
+            sparse_change.revision_valid_to = change.revision_valid_to
+
+            sparse_changes.append(sparse_change)
+        return sparse_changes
 
 
 class MinNumChangesDataFilter(AbstractDataFilter):

--- a/wikipedia_cleanup/data_filter.py
+++ b/wikipedia_cleanup/data_filter.py
@@ -87,6 +87,10 @@ class AbstractDataFilter(ABC):
 
 
 class DiscardAttributesDataFilter(AbstractDataFilter):
+    def __init__(self, attributes_to_keep: List[str]):
+        super().__init__()
+        self.attributes_to_keep = attributes_to_keep
+
     def _filter_for_property(self, changes: List[InfoboxChange]) -> List[InfoboxChange]:
         raise NotImplementedError("This method should never be called.")
 
@@ -94,62 +98,14 @@ class DiscardAttributesDataFilter(AbstractDataFilter):
         self, changes: List[InfoboxChange], initial_num_changes: int
     ) -> List[InfoboxChange]:
         self.filter_stats.initial_num_changes = initial_num_changes
-        self.filter_stats.input_num_changes = initial_num_changes
-        self.filter_stats.output_num_changes = initial_num_changes
+        self.filter_stats.input_num_changes = len(changes)
+        self.filter_stats.output_num_changes = len(changes)
 
         sparse_changes = []
         for change in changes:
             sparse_change: InfoboxChange = SparseInfoboxChange()  # type: ignore
-
-            sparse_change.page_id = change.page_id
-            sparse_change.property_name = change.property_name
-            sparse_change.value_valid_to = change.value_valid_to
-            sparse_change.value_valid_from = change.value_valid_from
-            sparse_change.current_value = change.current_value
-            sparse_change.previous_value = change.previous_value
-            sparse_change.num_changes = change.num_changes
-
-            sparse_change.page_title = change.page_title
-            sparse_change.revision_id = change.revision_id
-            sparse_change.edit_type = change.edit_type
-            sparse_change.property_type = change.property_type
-            sparse_change.comment = change.comment
-            sparse_change.infobox_key = change.infobox_key
-            sparse_change.username = change.username
-            sparse_change.user_id = change.user_id
-            sparse_change.position = change.position
-            sparse_change.template = change.template
-            sparse_change.revision_valid_to = change.revision_valid_to
-
-            sparse_changes.append(sparse_change)
-        return sparse_changes
-
-
-class TestDiscardAttributesDataFilter(AbstractDataFilter):
-    def _filter_for_property(self, changes: List[InfoboxChange]) -> List[InfoboxChange]:
-        raise NotImplementedError("This method should never be called.")
-
-    def filter(
-        self, changes: List[InfoboxChange], initial_num_changes: int
-    ) -> List[InfoboxChange]:
-        self.filter_stats.initial_num_changes = initial_num_changes
-        self.filter_stats.input_num_changes = initial_num_changes
-        self.filter_stats.output_num_changes = initial_num_changes
-
-        sparse_changes = []
-        for change in changes:
-            sparse_change: InfoboxChange = SparseInfoboxChange()  # type: ignore
-
-            sparse_change.page_id = change.page_id
-            sparse_change.property_name = change.property_name
-            sparse_change.value_valid_to = change.value_valid_to
-            sparse_change.value_valid_from = change.value_valid_from
-            sparse_change.current_value = change.current_value
-            sparse_change.previous_value = change.previous_value
-            sparse_change.num_changes = change.num_changes
-
-            sparse_change.infobox_key = change.infobox_key
-            sparse_change.revision_valid_to = change.revision_valid_to
+            for attribute in self.attributes_to_keep:
+                setattr(sparse_change, attribute, getattr(change, attribute))
 
             sparse_changes.append(sparse_change)
         return sparse_changes

--- a/wikipedia_cleanup/data_processing.py
+++ b/wikipedia_cleanup/data_processing.py
@@ -12,6 +12,7 @@ from tqdm.contrib.concurrent import process_map
 from wikipedia_cleanup.data_filter import (
     AbstractDataFilter,
     EditWarRevertsDataFilter,
+    TestDiscardAttributesDataFilter,
     filter_changes_with,
     generate_default_filters,
     get_stats_from_filters,
@@ -46,6 +47,7 @@ def json_to_infobox_changes(json_obj: Dict[Any, Any]) -> List[InfoboxChange]:
                 position=json_obj.get("position"),
                 template=json_obj.get("template"),
                 revision_valid_to=json_obj.get("validTo", None),
+                num_changes=1,
             )
         )
     return changes
@@ -178,6 +180,19 @@ if __name__ == "__main__":
     print(get_stats_from_filters(filters))
     filters = generate_default_filters()
     filters.append(EditWarRevertsDataFilter())
+    get_data(
+        Path(
+            "/run/media/secret/manjaro-home/secret/mp-data/"
+            "costum-format-filtered-dayly/costum-format-filtered-dayly"
+        ),
+        5,
+        1,
+        filters=filters,
+    )
+    print(get_stats_from_filters(filters))
+
+    filters = generate_default_filters()
+    filters.insert(0, TestDiscardAttributesDataFilter())
     get_data(
         Path(
             "/run/media/secret/manjaro-home/secret/mp-data/"

--- a/wikipedia_cleanup/data_processing.py
+++ b/wikipedia_cleanup/data_processing.py
@@ -11,8 +11,7 @@ from tqdm.contrib.concurrent import process_map
 
 from wikipedia_cleanup.data_filter import (
     AbstractDataFilter,
-    EditWarRevertsDataFilter,
-    TestDiscardAttributesDataFilter,
+    DiscardAttributesDataFilter,
     filter_changes_with,
     generate_default_filters,
     get_stats_from_filters,
@@ -162,7 +161,7 @@ def get_data(
 
 # local test
 if __name__ == "__main__":
-    get_data(
+    """get_data(
         Path("/home/secret/uni/Masterprojekt/data/test_case_data/output-infobox"),
         1000,
         3,
@@ -189,17 +188,16 @@ if __name__ == "__main__":
         1,
         filters=filters,
     )
-    print(get_stats_from_filters(filters))
+    print(get_stats_from_filters(filters))"""
 
     filters = generate_default_filters()
-    filters.insert(0, TestDiscardAttributesDataFilter())
-    get_data(
-        Path(
-            "/run/media/secret/manjaro-home/secret/mp-data/"
-            "costum-format-filtered-dayly/costum-format-filtered-dayly"
-        ),
-        5,
-        1,
-        filters=filters,
+    filters.append(DiscardAttributesDataFilter(["page_id", "property_name"]))
+    print(
+        get_data(
+            Path("/home/secret/uni/Masterprojekt/data/test_case_data/output-infobox"),
+            5,
+            1,
+            filters=filters,
+        ).head()
     )
     print(get_stats_from_filters(filters))

--- a/wikipedia_cleanup/data_processing.py
+++ b/wikipedia_cleanup/data_processing.py
@@ -12,6 +12,7 @@ from tqdm.contrib.concurrent import process_map
 from wikipedia_cleanup.data_filter import (
     AbstractDataFilter,
     DiscardAttributesDataFilter,
+    EditWarRevertsDataFilter,
     filter_changes_with,
     generate_default_filters,
     get_stats_from_filters,
@@ -161,7 +162,7 @@ def get_data(
 
 # local test
 if __name__ == "__main__":
-    """get_data(
+    get_data(
         Path("/home/secret/uni/Masterprojekt/data/test_case_data/output-infobox"),
         1000,
         3,
@@ -188,7 +189,7 @@ if __name__ == "__main__":
         1,
         filters=filters,
     )
-    print(get_stats_from_filters(filters))"""
+    print(get_stats_from_filters(filters))
 
     filters = generate_default_filters()
     filters.append(DiscardAttributesDataFilter(["page_id", "property_name"]))

--- a/wikipedia_cleanup/schema.py
+++ b/wikipedia_cleanup/schema.py
@@ -40,10 +40,26 @@ class InfoboxChange(BaseModel):
     revision_valid_to: Optional[
         datetime
     ] = None  # date of the next revision for that infobox
+
     # => revision_valid_to <= value_valid_to
 
     def __str__(self) -> str:
         return str(self.__dict__)
+
+
+"""
+Empty class that can be used to use less RAM. All attributes are basically optional.
+But optional would still cost us a nullptr.
+Therefore all attributes need to be added on manually.
+E.g.
+a = SparseInfoboxChange()
+a.page_id = change.page_id
+...
+"""
+
+
+class SparseInfoboxChange:
+    pass
 
 
 # Knowledge over json-files:

--- a/wikipedia_cleanup/schema.py
+++ b/wikipedia_cleanup/schema.py
@@ -47,18 +47,17 @@ class InfoboxChange(BaseModel):
         return str(self.__dict__)
 
 
-"""
-Empty class that can be used to use less RAM. All attributes are basically optional.
-But optional would still cost us a nullptr.
-Therefore all attributes need to be added on manually.
-E.g.
-a = SparseInfoboxChange()
-a.page_id = change.page_id
-...
-"""
-
-
 class SparseInfoboxChange:
+    """
+    Empty class that can be used to use less RAM. All attributes are basically optional.
+    But optional would still cost us a nullptr.
+    Therefore all attributes need to be added on manually.
+    E.g.
+    a = SparseInfoboxChange()
+    a.page_id = change.page_id
+    ...
+    """
+
     pass
 
 

--- a/wikipedia_cleanup/schema.py
+++ b/wikipedia_cleanup/schema.py
@@ -48,16 +48,6 @@ class InfoboxChange(BaseModel):
 
 
 class SparseInfoboxChange:
-    """
-    Empty class that can be used to use less RAM. All attributes are basically optional.
-    But optional would still cost us a nullptr.
-    Therefore all attributes need to be added on manually.
-    E.g.
-    a = SparseInfoboxChange()
-    a.page_id = change.page_id
-    ...
-    """
-
     pass
 
 


### PR DESCRIPTION
Currently, the reading is kind of slow and takes up a lot of space. Therefore, I added a simpler filter which appends all wanted attributes to a new plain object. This allows to load and save not all attributes that are available. It should be used by copying the default filter Class `DiscardAttributesDataFilter` and removing all  unwanted attributes